### PR TITLE
Handle negative values on `lifetime` variable

### DIFF
--- a/nginx_secure_links/storages.py
+++ b/nginx_secure_links/storages.py
@@ -142,9 +142,11 @@ class FileStorage(FileSystemStorage):
         if lifetime is None:
             # default lifetime
             expires_seconds = self.expires_seconds
-        elif lifetime <= 0:
+        elif lifetime == 0:
             # unlimited lifetime
             expires_seconds = None
+        elif lifetime < 0:
+            raise ValueError('The value of `lifetime` should not be negative.')
         else:
             expires_seconds = lifetime
         url = super().url(name)

--- a/nginx_secure_links/storages.py
+++ b/nginx_secure_links/storages.py
@@ -142,7 +142,7 @@ class FileStorage(FileSystemStorage):
         if lifetime is None:
             # default lifetime
             expires_seconds = self.expires_seconds
-        elif lifetime == 0:
+        elif lifetime <= 0:
             # unlimited lifetime
             expires_seconds = None
         else:

--- a/tests/tests/test_storage_url.py
+++ b/tests/tests/test_storage_url.py
@@ -1,5 +1,7 @@
 from urllib.parse import parse_qs, urlparse
 
+import pytest
+
 from nginx_secure_links import utils
 
 
@@ -124,14 +126,6 @@ def test_openssl_hashed_string_similarity_with_negative_lifetime(
     )
     assert int(dt_static_value.timestamp()) > expires_timestamp
 
-    try:
+    with pytest.raises(ValueError) as e:
         partially_private_storage.url(sample_path, lifetime=lifetime)
-        assert (
-            False
-        ), 'Expected `ValueError` to be raised with negative `lifetime`.'
-    except ValueError:
-        # expected behavior
-        pass
-    except:
-        # unexpected exception raised
-        assert False, 'Excpected to raise a `ValueError` exception.'
+    assert str(e.value) == 'The value of `lifetime` should not be negative.'

--- a/tests/tests/test_storage_url.py
+++ b/tests/tests/test_storage_url.py
@@ -107,3 +107,31 @@ def test_openssl_hashed_string_similarity_with_unlimited_lifetime(
     assert token_field_name in params
     assert expires_field_name not in params
     assert params[token_field_name][0] == sample_token
+
+
+def test_openssl_hashed_string_similarity_with_negative_lifetime(
+    dt_static_value,
+    storage_params_partially_private,
+    partially_private_storage,
+):
+    # /media/private/sample1.pdf secret_xyz
+    sample_path = 'private/sample1.pdf'
+    lifetime = -1
+
+    expires_timestamp = utils.gen_expires(
+        dt_static_value,
+        seconds=lifetime,
+    )
+    assert int(dt_static_value.timestamp()) > expires_timestamp
+
+    try:
+        partially_private_storage.url(sample_path, lifetime=lifetime)
+        assert (
+            False
+        ), 'Expected `ValueError` to be raised with negative `lifetime`.'
+    except ValueError:
+        # expected behavior
+        pass
+    except:
+        # unexpected exception raised
+        assert False, 'Excpected to raise a `ValueError` exception.'


### PR DESCRIPTION
if for some reason a negative value reach the `lifetime` it will be an unexpected/undesired `410` on the nginx processing